### PR TITLE
Fixed permissions cooldown override issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,6 @@ FakesAssemblies/
 GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
+
+# IntelliJ Rider 
+.idea/

--- a/Rocket.Core/Permissions/RocketPermissionsHelper.cs
+++ b/Rocket.Core/Permissions/RocketPermissionsHelper.cs
@@ -138,12 +138,10 @@ namespace Rocket.Core.Permissions
                     if (permission.Name.StartsWith("-"))
                     {
                         result.RemoveAll(x => string.Equals(x.Name, permission.Name.Substring(1), StringComparison.InvariantCultureIgnoreCase));
-                    } else if (result.Contains(permission))
+                    } 
+                    else 
                     {
-                        result.Remove(permission);
-                        result.Add(permission);
-                    } else
-                    {
+                        result.RemoveAll(x => x.Name == permission.Name);
                         result.Add(permission);
                     }
 


### PR DESCRIPTION
There's a few things people need to know:

1. In previous PR I removed implicit "base" permission because it's wrong (it wouldn't work for _x.y.bla_ because it only gave _x_). Thus now you need to explicitly specify _kit_ or _vault_ permission for corresponding command.
2. Permission priority is the higher the lower the value is.
3. Permissions are based on priority so highest priority wins. It's recommended to actually set different group priorities. Apart from that it's better not to set parent group priority to higher than it's child group priority otherwise cooldowns will be taken from parent group.