### PR TITLE
RCON Code Updates Round 2.

### DIFF
--- a/Rocket.Core/RCON/RCONConnection.cs
+++ b/Rocket.Core/RCON/RCONConnection.cs
@@ -30,7 +30,7 @@ namespace Rocket.Core.RCON
 
         public string Read()
         {
-            return RCONServer.Read(Client);
+            return RCONServer.Read(Client, Authenticated);
         }
 
         public void Close()

--- a/Rocket.Core/RCON/RCONConnection.cs
+++ b/Rocket.Core/RCON/RCONConnection.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net.Sockets;
 using System.Linq;
+using System;
 
 namespace Rocket.Core.RCON
 {
@@ -8,12 +9,16 @@ namespace Rocket.Core.RCON
         public TcpClient Client;
         public bool Authenticated;
         public bool Interactive;
+        public int InstanceID { get; private set; }
+        public DateTime ConnectedTime { get; private set; }
 
-        public RCONConnection(TcpClient client)
+        public RCONConnection(TcpClient client, int instance)
         {
             this.Client = client;
             Authenticated = false;
             Interactive = true;
+            InstanceID = instance;
+            ConnectedTime = DateTime.Now;
         }
 
         public void Send(string command, bool nonewline = false)
@@ -35,11 +40,11 @@ namespace Rocket.Core.RCON
 
         public void Close()
         {
-            this.Client.Close();
-            return;
+            if (Client.Client.Connected)
+                Client.Close();
         }
 
-        public string Address { get { return this.Client.Client.RemoteEndPoint.ToString(); } }
+        public string Address { get { return Client.Client.Connected ? Client.Client.RemoteEndPoint.ToString() : "?"; } }
     }
 
 }

--- a/Rocket.Core/RCON/RCONServer.cs
+++ b/Rocket.Core/RCON/RCONServer.cs
@@ -149,7 +149,7 @@ namespace Rocket.Core.RCON
                         continue;
                     }
                     if (command != "ia")
-                        Logger.Log("Client has executed command \"" + command + "\"");
+                        Logger.Log("Client ID: " + newclient.InstanceID + " has executed command \"" + command + "\"");
 
                     lock (commands)
                     {
@@ -162,7 +162,7 @@ namespace Rocket.Core.RCON
                 clients.Remove(newclient);
                 newclient.Send("Good bye!");
                 Thread.Sleep(1500);
-                Logger.Log("Client has disconnected! (IP: " + newclient.Address + ")");
+                Logger.Log("Client ID: " + newclient.InstanceID + " has disconnected! (IP: " + newclient.Address + ")");
                 newclient.Close();
 
             }

--- a/Rocket.Core/RCON/RCONServer.cs
+++ b/Rocket.Core/RCON/RCONServer.cs
@@ -83,6 +83,16 @@ namespace Rocket.Core.RCON
                     Thread.Sleep(100);
                     command = newclient.Read();
                     if (command == "") break;
+                    if (!newclient.Authenticated)
+                    {
+                        nonAuthCommandCount++;
+                        if (nonAuthCommandCount > 4)
+                        {
+                            newclient.Send("Error: Too many commands sent before Authentication!\r\n");
+                            Logger.LogWarning("Client has sent too many commands before Authentication!");
+                            break;
+                        }
+                    }
                     command = command.TrimEnd('\n', '\r', ' ');
                     if (command == "quit") break;
                     if (command == "ia")

--- a/Rocket.Core/Serialization/RocketSettings.cs
+++ b/Rocket.Core/Serialization/RocketSettings.cs
@@ -16,6 +16,14 @@ namespace Rocket.Core.Serialization
         public ushort Port = 27115;
         [XmlAttribute]
         public string Password = "changeme";
+        [XmlAttribute]
+        public bool EnableMaxGlobalConnections = true;
+        [XmlAttribute]
+        public ushort MaxGlobalConnections = 10;
+        [XmlAttribute]
+        public bool EnableMaxLocalConnections = true;
+        [XmlAttribute]
+        public ushort MaxLocalConnections = 3;
     }
 
     public sealed class AutomaticShutdown


### PR DESCRIPTION
This is the second round of updates to RCON from the one I did a few days ago.

This update increases support for more RCON(telnet) clients. It supports those that use \r control codes to separate lines(mac return code, and used in some batching features in some telnet clients.). It also ignores the connection preamble that Putty sends to the server when it connects, you no longer have to hit return once to be able to type in the login command on the Putty client.

There was some connection control features added too, configurable max concurrent global(server wide) and local(per IP.) connections to RCON, and a max number of unauthed commands feature was also added.

There were also some further changes made to add support to RCON info/control commands that I'm going to add to Rocket.Unturned. Commands for Rocket.Unturned are currently: rwho(lists all connected clients.), rkick <ConnectionID> (kicks a clients from the server), rflush (kicks all clients from the server.).