### PR TITLE
Add commands for RCON info/Control.

### DIFF
--- a/Rocket.Core/Commands/CommandRFlush.cs
+++ b/Rocket.Core/Commands/CommandRFlush.cs
@@ -1,0 +1,66 @@
+﻿using Rocket.API;
+using Rocket.Core.Logging;
+using Rocket.Core.RCON;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Rocket.Core.Commands
+{
+    class CommandRFlush : IRocketCommand
+    {
+        public List<string> Aliases
+        {
+            get { return new List<string>(); }
+        }
+
+        public AllowedCaller AllowedCaller
+        {
+            get { return AllowedCaller.Console; }
+        }
+
+        public string Help
+        {
+            get { return "Kicks all RCON clients off of the server."; }
+        }
+
+        public string Name
+        {
+            get { return "rflush"; }
+        }
+
+        public List<string> Permissions
+        {
+            get { return new List<string>() { "rocket.rflush" }; }
+        }
+
+        public string Syntax
+        {
+            get { return ""; }
+        }
+
+        public void Execute(IRocketPlayer caller, string[] command)
+        {
+            if (command.Length == 0 || command.Length > 1 || command[0] != "y")
+            {
+                Logger.Log(R.Translate("command_rflush_help"));
+            }
+            else
+            {
+                Logger.Log(R.Translate("command_rflush_total", RCONServer.Clients.Count.ToString()));
+                List<RCONConnection> connections = new List<RCONConnection>();
+                connections.AddRange(RCONServer.Clients);
+                for (int i = 0; i < connections.Count; i++)
+                {
+                    RCONConnection client = connections[i];
+                    if (client.Client.Client.Connected)
+                    {
+                        Logger.Log(R.Translate("command_rflush_line", i + 1, client.InstanceID, client.Address));
+                        client.Close();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Rocket.Core/Commands/CommandRKick.cs
+++ b/Rocket.Core/Commands/CommandRKick.cs
@@ -1,0 +1,64 @@
+﻿using Rocket.API;
+using Rocket.API.Extensions;
+using Rocket.Core.Logging;
+using Rocket.Core.RCON;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Rocket.Core.Commands
+{
+    class CommandRKick : IRocketCommand
+    {
+        public List<string> Aliases
+        {
+            get { return new List<string>(); }
+        }
+
+        public AllowedCaller AllowedCaller
+        {
+            get { return AllowedCaller.Console; }
+        }
+
+        public string Help
+        {
+            get { return "Kicks a client off of RCON."; }
+        }
+
+        public string Name
+        {
+            get { return "rkick"; }
+        }
+
+        public List<string> Permissions
+        {
+            get { return new List<string>() { "rocket.rkick" }; }
+        }
+
+        public string Syntax
+        {
+            get { return "<ConnectionID>"; }
+        }
+
+        public void Execute(IRocketPlayer caller, string[] command)
+        {
+            int? instance = command.GetInt32Parameter(0);
+            if (command.Length == 0 || command.Length > 1 || instance == null)
+            {
+                Logger.Log(R.Translate("command_rkick_help"));
+                return;
+            }
+            foreach (RCONConnection client in RCONServer.Clients)
+            {
+                if (client.InstanceID == (int)instance)
+                {
+                    Logger.Log(R.Translate("command_rkick_kicked", instance.ToString(), client.Address));
+                    client.Close();
+                    return;
+                }
+            }
+            Logger.Log(R.Translate("command_rkick_notfound", instance.ToString()));
+        }
+    }
+}

--- a/Rocket.Core/Commands/CommandRWho.cs
+++ b/Rocket.Core/Commands/CommandRWho.cs
@@ -1,0 +1,69 @@
+﻿using Rocket.API;
+using Rocket.Core.Logging;
+using Rocket.Core.RCON;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Rocket.Core.Commands
+{
+    class CommandRWho : IRocketCommand
+    {
+        public List<string> Aliases
+        {
+            get { return new List<string>(); }
+        }
+
+        public AllowedCaller AllowedCaller
+        {
+            get { return AllowedCaller.Console; }
+        }
+
+        public string Help
+        {
+            get { return "Returns a list of clients connected to RCON."; }
+        }
+
+        public string Name
+        {
+            get { return "rwho"; }
+        }
+
+        public List<string> Permissions
+        {
+            get { return new List<string>() { "rocket.rwho" }; }
+        }
+
+        public string Syntax
+        {
+            get { return ""; }
+        }
+
+        public void Execute(IRocketPlayer caller, string[] command)
+        {
+            for (int i = 0; i < RCONServer.Clients.Count; i++)
+            {
+                RCONConnection client = RCONServer.Clients[i];
+                int timeTotal = (int)((DateTime.Now - client.ConnectedTime).TotalSeconds);
+                string connectedTimeFormat = "";
+
+                // Format days, hours minutes and seconds since the client connected to RCON.
+                if (timeTotal >= (60 * 60 * 24))
+                {
+                    connectedTimeFormat = ((int)(timeTotal / (60 * 60 * 24))).ToString() + "d ";
+                }
+                if (timeTotal >= (60 * 60))
+                {
+                    connectedTimeFormat += ((int)((timeTotal / (60 * 60)) % 24)).ToString() + "h ";
+                }
+                if (timeTotal >= 60)
+                {
+                    connectedTimeFormat += ((int)((timeTotal / 60) % 60)).ToString() + "m ";
+                }
+                connectedTimeFormat += ((int)(timeTotal % 60)).ToString() + "s";
+                Logger.Log(R.Translate("command_rwho_line", i + 1, client.InstanceID, client.Authenticated, client.Address, client.ConnectedTime.ToString(), connectedTimeFormat));
+            }
+        }
+    }
+}

--- a/Rocket.Core/R.cs
+++ b/Rocket.Core/R.cs
@@ -12,6 +12,7 @@ using Rocket.API.Collections;
 using Rocket.Core.Extensions;
 using Rocket.Core.Logging;
 using Rocket.Core.Commands;
+using System.Reflection;
 
 namespace Rocket.Core
 {
@@ -32,6 +33,13 @@ namespace Rocket.Core
         private static readonly TranslationList defaultTranslations = new TranslationList(){
                 {"rocket_join_public","{0} connected to the server" },
                 {"rocket_leave_public","{0} disconnected from the server"},
+                { "command_rwho_line", "#{0}, Connection ID: {1}, Authed: {2}, Address: {3}, Time Connected: {4}, Connected For: {5}." },
+                { "command_rkick_help", "Usage: rkick <ConnectionID> - Kicks a client off of RCON." },
+                { "command_rkick_notfound", "Error: RCON Client with Connection ID: {0} not found!" },
+                { "command_rkick_kicked", "RCON Client kicked with Connection ID: {0}, Address: {1}!" },
+                { "command_rflush_help", "Usage: rflush <y> - kicks all connected RCON clients on the server." },
+                { "command_rflush_total", "Closing {0} RCON connections." },
+                { "command_rflush_line", "#{0}, ConnectionID: {1}, Address: {2}, closed!" },
                 {"command_no_permission","You do not have permissions to execute this command."},
                 {"command_cooldown","You have to wait {0} seconds before you can use this command again."}
         };
@@ -67,6 +75,9 @@ namespace Rocket.Core
                 Permissions = gameObject.TryAddComponent<RocketPermissionsManager>();
                 Plugins = gameObject.TryAddComponent<RocketPluginManager>();
                 Commands = gameObject.TryAddComponent<RocketCommandManager>();
+
+                // Load Commands from Rocket.Core.Commands.
+                Commands.RegisterFromAssembly(Assembly.GetExecutingAssembly());
 
                 if (Settings.Instance.MaxFrames < 10 && Settings.Instance.MaxFrames != -1) Settings.Instance.MaxFrames = 10;
                 Application.targetFrameRate = Settings.Instance.MaxFrames;

--- a/Rocket.Core/Rocket.Core.csproj
+++ b/Rocket.Core/Rocket.Core.csproj
@@ -61,6 +61,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Commands\CommandRFlush.cs" />
+    <Compile Include="Commands\CommandRKick.cs" />
+    <Compile Include="Commands\CommandRWho.cs" />
     <Compile Include="Commands\RocketCommandAttribute.cs" />
     <Compile Include="Commands\RocketCommandManager.cs" />
     <Compile Include="Debugger.cs" />


### PR DESCRIPTION
As per fr34kyn01535 suggestion in the previous PR, the commands for RCON info/control were transferred to Rocket.Core. The commands are located in Rocket.Core.Commands, and the R class has been updated to load commands from Rocket.Core.

The commands added here are:
rwho - Lists the currently connected RCON clients on the server, with some extra info like: Connection ID, Currently Authed(true/false), IP Address, Connected Time, and the amount of time they've been connected to the server.
rkick <Connection ID> - Kick's a RCON client by their Connection ID.
rflush <y> - Kicks all clients off of RCON, execute with y to execute the flush, otherwise you'll get the help message.