### PR TITLE
Replaced the method of execution in the TaskDispatcher.

### DIFF
--- a/Rocket.API/Utils/TaskDispatcher.cs
+++ b/Rocket.API/Utils/TaskDispatcher.cs
@@ -174,9 +174,9 @@ namespace Rocket.API.Utils
                 QueuedMainActionsBuffer?.Clear();
             }
 
-            lock (QueuedAsyncActionsBuffer)
+            lock (QueuedMainFixedActionsBuffer)
             {
-                QueuedAsyncActionsBuffer?.Clear();
+                QueuedMainFixedActionsBuffer?.Clear();
             }
 
             _thread?.Interrupt();

--- a/Rocket.API/Utils/TaskDispatcher.cs
+++ b/Rocket.API/Utils/TaskDispatcher.cs
@@ -22,7 +22,7 @@ namespace Rocket.API.Utils
         private Thread _thread;
 
         //This will allow greater control over the interation of the secondary Thread.
-        private bool runThread = default(bool);
+        private volatile bool runThread = default(bool);
 
         protected void Awake()
         {

--- a/Rocket.API/Utils/TaskDispatcher.cs
+++ b/Rocket.API/Utils/TaskDispatcher.cs
@@ -205,6 +205,8 @@ namespace Rocket.API.Utils
             QueuedMainActions.Clear();
             QueuedMainFixedActions.Clear();
 
+            _thread = null;
+
             //Wouldn't join be better to avoid any I/O corruption?
             //_thread?.Interrupt();
 


### PR DESCRIPTION
**~~WIP, I need to test that this is Thread-Safe before fully merging.~~**
**This is now ready to merge.**

This is just a small change to help prevent a long list of actions from keeping a lock on the object too long (possibly stalling another `Thread` attempting to obtain the lock) by using a set of `Queue` buffers. I can also change the back to using the `List` instead of a `Queue` if you guys would like.

This also fixes a bug when the `TaskDispatcher` is shutdown where the `QueuedMainFixedActions` is not cleared and the `QueuedAyncActions` is cleared twice.