### PR TITLE
Fixing IPlayer.IsAdmin

### DIFF
--- a/Rocket.API/Player/IPlayer.cs
+++ b/Rocket.API/Player/IPlayer.cs
@@ -6,6 +6,6 @@ namespace Rocket.API.Player
     {
         string UniqueID { get; }
         string DisplayName { get; }
-        string IsAdmin { get; }
+        bool IsAdmin { get; }
     }
 }


### PR DESCRIPTION
Changing `IPlayer.IsAdmin` from a `string` to a `bool`.