### PR TITLE
Added more Plugin events

### DIFF
--- a/Rocket.Core/Events/Plugins/PluginsPostLoadedEvent.cs
+++ b/Rocket.Core/Events/Plugins/PluginsPostLoadedEvent.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Rocket.API.Eventing;
+
+namespace Rocket.Core.Events.Plugins
+{
+    public sealed class PluginsPostLoadedEvent : Event
+    {
+        internal PluginsPostLoadedEvent(bool global = true) : base(global) { }
+
+        internal PluginsPostLoadedEvent(EventExecutionTargetContext executionTarget = EventExecutionTargetContext.Sync, bool global = true) : base(executionTarget, global) { }
+
+        internal PluginsPostLoadedEvent(string name = null, EventExecutionTargetContext executionTarget = EventExecutionTargetContext.Sync, bool global = true) : base(name, executionTarget, global) { }
+    }
+}
+

--- a/Rocket.Core/Events/Plugins/PluginsPreLoadedEvent.cs
+++ b/Rocket.Core/Events/Plugins/PluginsPreLoadedEvent.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Rocket.API.Eventing;
+
+namespace Rocket.Core.Events.Plugins
+{
+    public sealed class PluginsPreLoadedEvent : Event
+    {
+        internal PluginsPreLoadedEvent(bool global = true) : base(global) { }
+
+        internal PluginsPreLoadedEvent(EventExecutionTargetContext executionTarget = EventExecutionTargetContext.Sync, bool global = true) : base(executionTarget, global) { }
+
+        internal PluginsPreLoadedEvent(string name = null, EventExecutionTargetContext executionTarget = EventExecutionTargetContext.Sync, bool global = true) : base(name, executionTarget, global) { }
+    }
+}

--- a/Rocket.Core/Rocket.Core.csproj
+++ b/Rocket.Core/Rocket.Core.csproj
@@ -70,6 +70,8 @@
     <Compile Include="Events\Plugins\PluginEvent.cs" />
     <Compile Include="Events\Plugins\PluginLoadedEvent.cs" />
     <Compile Include="Events\Plugins\PluginLoadEvent.cs" />
+    <Compile Include="Events\Plugins\PluginsPostLoadedEvent.cs" />
+    <Compile Include="Events\Plugins\PluginsPreLoadedEvent.cs" />
     <Compile Include="Events\Plugins\PluginUnloadedEvent.cs" />
     <Compile Include="Events\Plugins\PluginUnloadEvent.cs" />
     <Compile Include="Exceptions\IFriendlyException.cs" />


### PR DESCRIPTION
This adds two new events:

- `PluginsPreLoadedEvent` which is called after the assemblies are loaded and the `IDependencyRegistrator` of each plugin is called.

- `PluginsPostLoadedEvent` which is called after each plugin has `IPlugin.Load()` called.