### PR TITLE
Fixed an exception.

### DIFF
--- a/Rocket.Core/Plugins/PluginManager.cs
+++ b/Rocket.Core/Plugins/PluginManager.cs
@@ -195,7 +195,14 @@ namespace Rocket.Core.Plugins
             return !plugin.IsAlive;
         }
 
-        public IEnumerable<IPlugin> Plugins => container.GetAll<IPlugin>();
+        public IEnumerable<IPlugin> Plugins
+        {
+            get
+            {
+                container.TryGetAll<IPlugin>(out var plugins);
+                return plugins;
+            }
+        }
 
         public bool ExecutePluginDependendCode(string pluginName, Action<IPlugin> action)
         {


### PR DESCRIPTION
This prevents `Rocket.Core.PluginManager.Plugins` from throwing an exception when there are no plugins loaded.