### PR TITLE
Fixed an exception.

### DIFF
--- a/Rocket.Core/Plugins/PluginManager.cs
+++ b/Rocket.Core/Plugins/PluginManager.cs
@@ -55,9 +55,9 @@ namespace Rocket.Core.Plugins
         {
             get
             {
-                return commands
+                return commands?
                        .Where(c => c.Key.IsAlive)
-                       .SelectMany(c => c.Value);
+                       .SelectMany(c => c.Value) ?? new List<ICommand>();
             }
         }
 


### PR DESCRIPTION
Fixes a small exception where the `commands` array in `DefaultCommandHandler` would be null causing the LINQ expression to fail.