### PR TITLE
[IB] Re-added Command Permissions

### DIFF
--- a/Rocket.API/Commands/ICommand.cs
+++ b/Rocket.API/Commands/ICommand.cs
@@ -65,6 +65,24 @@ namespace Rocket.API.Commands
         string Description { get; }
 
         /// <summary>
+        ///     The permission required to execute the command.
+        ///     <para>
+        ///         <b>This property can return null.</b>
+        ///     </para>
+        /// </summary>
+        /// <remarks>
+        ///     When returning null, the default permission will be used, which depends on the <see cref="ICommandHandler" />
+        ///     implementation.
+        ///     <para>
+        ///         The default CommandHandler uses {PluginName}.{CommandName} (e.g. "MyPlugin.Heal") as permission.
+        ///     </para>
+        /// </remarks>
+        /// <example>
+        ///     <c>"MyPermission.Heal"</c>
+        /// </example>
+        string Permission { get; }
+
+        /// <summary>
         ///     The command syntax will be shown to the <see cref="IUser" /> when the command was not used correctly.
         ///     <para>An output for the above example could be "/heal [player] &lt;amount&gt;".</para>
         ///     <para>The syntax should not contain Child Command usage.</para>

--- a/Rocket.Core/Commands/CommandAttribute.cs
+++ b/Rocket.Core/Commands/CommandAttribute.cs
@@ -12,5 +12,7 @@ namespace Rocket.Core.Commands
         public string Syntax { get; set; }
 
         public string Description { get; set; }
+
+        public string Permission { get; set; }
     }
 }

--- a/Rocket.Core/Commands/CommandAttributeWrapper.cs
+++ b/Rocket.Core/Commands/CommandAttributeWrapper.cs
@@ -17,7 +17,7 @@ namespace Rocket.Core.Commands
         public CommandAttributeWrapper(object instance, MethodBase method,
                                        CommandAttribute attribute,
                                        string[] aliases,
-                                       Type[] supportedUsers)
+                                       Type[] supportedUsers, string permission)
         {
             this.supportedUsers = supportedUsers;
             Instance = instance;
@@ -25,6 +25,7 @@ namespace Rocket.Core.Commands
             Attribute = attribute;
             Name = attribute?.Name ?? method.Name;
             Syntax = attribute?.Syntax ?? BuildSyntaxFromMethod();
+            Permission = permission;
 
             Aliases = aliases;
         }
@@ -37,6 +38,7 @@ namespace Rocket.Core.Commands
         public string Summary => Attribute?.Summary;
         public string Description => Attribute?.Description;
         public string Syntax { get; }
+        public string Permission { get; }
         public IChildCommand[] ChildCommands { get; } //todo
         public string[] Aliases { get; }
 

--- a/Rocket.Core/Commands/ProxyCommand.cs
+++ b/Rocket.Core/Commands/ProxyCommand.cs
@@ -19,6 +19,7 @@ namespace Rocket.Core.Commands {
         public string[] Aliases => BaseCommand.Aliases;
         public string Summary => BaseCommand.Summary;
         public string Description => BaseCommand.Description;
+        public string Permission => BaseCommand.Permission;
         public string Syntax => BaseCommand.Syntax;
         public IChildCommand[] ChildCommands => BaseCommand.ChildCommands;
         public bool SupportsUser(Type user) => BaseCommand.SupportsUser(user);

--- a/Rocket.Core/Commands/RocketCommands/CommandHelp.cs
+++ b/Rocket.Core/Commands/RocketCommands/CommandHelp.cs
@@ -14,6 +14,7 @@ namespace Rocket.Core.Commands.RocketCommands
         public string Name => "Help";
         public string[] Aliases => new[] {"h"};
         public string Summary => "Provides help for all or a specific command.";
+        public string Permission => "Rocket.Help";
         public string Description => null;
         public string Syntax => "[command] [1. Child Command] [2. Child Command] [...]";
         public IChildCommand[] ChildCommands => null;
@@ -23,9 +24,9 @@ namespace Rocket.Core.Commands.RocketCommands
         public void Execute(ICommandContext context)
         {
             ICommandProvider cmdProvider = context.Container.Resolve<ICommandProvider>();
-            ICommandHandler cmdHandler = context.Container.Resolve<ICommandHandler>();
-
+            
             IPermissionProvider permissionProvider = context.Container.Resolve<IPermissionProvider>();
+            ICommandHandler cmdHandler = context.Container.Resolve<ICommandHandler>();
 
             string rootPrefix = context.RootContext.CommandPrefix;
             IEnumerable<ICommand> childs = cmdProvider.Commands.OrderBy(c => c.Name);
@@ -40,7 +41,7 @@ namespace Rocket.Core.Commands.RocketCommands
                 {
                     cmd = childs?.GetCommand(commandNode, context.User);
 
-                    if (cmd == null || !HasAccess(cmd, context.User))
+                    if (cmd == null || !HasAccess(cmd, context.User, permissionProvider))
                     {
                         context.User.SendMessage("Command was not found: " + prefix + commandNode, Color.Red);
                         return;
@@ -51,7 +52,7 @@ namespace Rocket.Core.Commands.RocketCommands
                         prefix += commandNode + " ";
                     i++;
                 }
-
+                
                 context.User.SendMessage(GetCommandUsage(cmd, prefix), Color.Blue);
 
                 if (cmd.Description != null)
@@ -59,7 +60,7 @@ namespace Rocket.Core.Commands.RocketCommands
 
                 List<ICommand> childCommands =
                     (cmd.ChildCommands?.Cast<ICommand>().ToList() ?? new List<ICommand>())
-                    .Where(c => HasAccess(c, context.User))
+                    .Where(c => HasAccess(c, context.User, permissionProvider))
                     .OrderBy(c => c.Name)
                     .ToList();
 
@@ -76,12 +77,15 @@ namespace Rocket.Core.Commands.RocketCommands
             context.User.SendMessage("Available commands: ", Color.Green);
 
             foreach (ICommand cmd in cmdProvider.Commands.OrderBy(c => c.Name))
-                if (HasAccess(cmd, context.User))
+                if (HasAccess(cmd, context.User, permissionProvider))
                     context.User.SendMessage(GetCommandUsage(cmd, rootPrefix), Color.Blue);
         }
 
-        public bool HasAccess(ICommand command, IUser user) 
-            => command.SupportsUser(user.GetType());
+        public bool HasAccess(ICommand command, IUser user, IPermissionProvider permissionProvider)
+            => permissionProvider.CheckPermission(user, command.Permission ?? command.Name)
+                == PermissionResult.Grant
+                && command.SupportsUser(user.GetType());
+
 
         public string GetCommandUsage(ICommand command, string prefix) => prefix
             + command.Name.ToLower()

--- a/Rocket.Core/Commands/RocketCommands/CommandLegacyMigration.cs
+++ b/Rocket.Core/Commands/RocketCommands/CommandLegacyMigration.cs
@@ -19,6 +19,7 @@ namespace Rocket.Core.Commands.RocketCommands
         public string[] Aliases => null;
         public string Summary => "Migrates from old RocketMod 4";
         public string Description => null;
+        public string Permission => "Rocket.Migrate.Legacy";
         public string Syntax => "[step]";
         public IChildCommand[] ChildCommands => null;
 

--- a/Rocket.Core/Commands/RocketCommands/CommandMigrateConfig.cs
+++ b/Rocket.Core/Commands/RocketCommands/CommandMigrateConfig.cs
@@ -14,6 +14,7 @@ namespace Rocket.Core.Commands.RocketCommands
         public string[] Aliases => null;
         public string Summary => "Migrates configs from one type to another.";
         public string Description => null;
+        public string Permission => "Rocket.Migrate.Config";
         public string Syntax => "[<from type> <to type> <path>]";
         public IChildCommand[] ChildCommands { get; }
 

--- a/Rocket.Core/Commands/RocketCommands/CommandPermission.cs
+++ b/Rocket.Core/Commands/RocketCommands/CommandPermission.cs
@@ -14,6 +14,7 @@ namespace Rocket.Core.Commands.RocketCommands
         public string Name => "Permission";
         public string Syntax => "";
         public string Summary => "Manages rocket permissions.";
+        public string Permission => "Rocket.Permissions.ManagePermissions";
         public string Description => null;
 
         public IChildCommand[] ChildCommands => new IChildCommand[]
@@ -141,6 +142,7 @@ namespace Rocket.Core.Commands.RocketCommands
         public string Summary => "Reloads permissions.";
         public string Description => null;
         public string Syntax => "";
+        public string Permission => "Rocket.Permissions.ManagePermissions.Reload";
         public IChildCommand[] ChildCommands => null;
         public string[] Aliases => new[] {"R"};
 

--- a/Rocket.Core/Commands/RocketCommands/CommandPermissionGroup.cs
+++ b/Rocket.Core/Commands/RocketCommands/CommandPermissionGroup.cs
@@ -18,6 +18,7 @@ namespace Rocket.Core.Commands.RocketCommands
 
         public string Summary => "Manages permission groups.";
         public string Description => null;
+        public string Permission => "Rocket.Permissions.ManageGroups";
 
         public string[] Aliases => new[] { "PG" };
 

--- a/Rocket.Core/Commands/RocketCommands/CommandRocket.cs
+++ b/Rocket.Core/Commands/RocketCommands/CommandRocket.cs
@@ -16,6 +16,7 @@ namespace Rocket.Core.Commands.RocketCommands
     {
         public string Name => "Rocket";
         public string Syntax => "";
+        public string Permission => "Rocket.ManageRocket";
         public string Summary => "Manages RocketMod.";
         public string Description => null;
         public string[] Aliases => null;
@@ -39,6 +40,7 @@ namespace Rocket.Core.Commands.RocketCommands
     {
         public string Name => "Reload";
         public string Summary => "Reloads RocketMod and all plugins.";
+        public string Permission => "Rocket.ManageRocket.Reload";
         public string Description => null;
         public string Syntax => "";
         public IChildCommand[] ChildCommands => null;
@@ -65,6 +67,7 @@ namespace Rocket.Core.Commands.RocketCommands
         public string[] Aliases => null;
         public string Summary => "Installs a plugin";
         public string Description => null;
+        public string Permission => "Rocket.ManageRocket.Install";
         public string Syntax => "<repo> <plugin> [version] [-Pre]";
         public IChildCommand[] ChildCommands => null;
 
@@ -129,6 +132,7 @@ namespace Rocket.Core.Commands.RocketCommands
         public string[] Aliases => null;
         public string Summary => "Uninstalls plugin";
         public string Description => null;
+        public string Permission => "Rocket.ManageRocket.Uninstall";
         public string Syntax => "<repo> <plugin>";
         public IChildCommand[] ChildCommands => null;
 
@@ -173,6 +177,7 @@ namespace Rocket.Core.Commands.RocketCommands
         public string[] Aliases => null;
         public string Summary => "Updates plugin";
         public string Description => null;
+        public string Permission => "Rocket.ManageRocket.Update";
         public string Syntax => "<repo> <plugin> [version] [-Pre]";
         public IChildCommand[] ChildCommands => null;
 
@@ -231,6 +236,7 @@ namespace Rocket.Core.Commands.RocketCommands
         public string[] Aliases => new[] { "v" };
         public string Summary => "RocketMod version";
         public string Description => null;
+        public string Permission => "Rocket.ManageRocket.Version";
         public string Syntax => "";
         public IChildCommand[] ChildCommands => null;
         public bool SupportsUser(Type user)

--- a/Rocket.Core/Plugins/ClrPluginLoader.cs
+++ b/Rocket.Core/Plugins/ClrPluginLoader.cs
@@ -250,7 +250,8 @@ namespace Rocket.Core.Plugins
 
                 CommandAttributeWrapper wrapper = new CommandAttributeWrapper(@object, method, cmdAttr,
                     aliasAttrs.Select(c => c.AliasName).ToArray(),
-                    supportedTypeAttrs.Select(c => c.UserType).ToArray());
+                    supportedTypeAttrs.Select(c => c.UserType).ToArray(),
+                    cmdAttr.Permission);
 
                 pluginContainer.RegisterSingletonInstance<ICommand>(wrapper, wrapper.Name);
             }


### PR DESCRIPTION
This is a pull to add the permission system as it was.

Without having customizable permission nodes, everything feels messy; this is especially true in Eco where there are 100+ commands to account for.

With this system, I am able to organize the permissions into groups based on the accessibility, use, ect, (See Discord Chat).

Even with these additions, this is optional. If a plugin opts to set the permissions field to `null`, then it will use the system currently in place to create the permission based on the context.