### PR TITLE
Make IPlayerEntity and IPlayerUser covariant

### DIFF
--- a/Rocket.API/Player/IPlayerEntity.cs
+++ b/Rocket.API/Player/IPlayerEntity.cs
@@ -7,7 +7,7 @@ namespace Rocket.API.Player
     /// <summary>
     ///     Represents a player entity.
     /// </summary>
-    public interface IPlayerEntity<TPlayer> : IEntity where TPlayer : IPlayer
+    public interface IPlayerEntity<out TPlayer> : IEntity where TPlayer : IPlayer
     {
         TPlayer Player { get; }
     }

--- a/Rocket.API/Player/IPlayerUser.cs
+++ b/Rocket.API/Player/IPlayerUser.cs
@@ -7,7 +7,7 @@ namespace Rocket.API.Player
         IPlayer Player { get; }
     }
 
-    public interface IPlayerUser<TPlayer> : IPlayerUser where TPlayer: IPlayer
+    public interface IPlayerUser<out TPlayer> : IPlayerUser where TPlayer: IPlayer
     {
         new TPlayer Player { get; }
     }


### PR DESCRIPTION
Allows to use ``entity is IPlayerEntity<IPlayer>`` instead of ``entity is IPlayerEntity<UnturnedPlayer>``